### PR TITLE
Release 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ether-system-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ether-system-react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A React version of the Ether System libraries",
   "main": "index.js",
   "private": true,


### PR DESCRIPTION
# Release 1.0.1

* Downgrades `styled-components` to latest stable version (4.0-beta was interfering with Jest snapshots)
* Color Variables demo now shows linked `color.*` variables instead of hex values